### PR TITLE
Update JSON API permissions

### DIFF
--- a/backend/campaign/views.py
+++ b/backend/campaign/views.py
@@ -15,7 +15,12 @@ class CampaignViewSet(viewsets.ModelViewSet):
 
     queryset = Campaign.objects.all()
     serializer_class = CampaignSerializer
-    permission_classes = [permissions.IsAuthenticated]
+
+    def get_permissions(self):
+        """Get permissions by action."""
+        if self.request.method == "GET":
+            return [permissions.AllowAny()]
+        return [permissions.IsAuthenticated()]
 
 
 class CommentViewSet(viewsets.ModelViewSet):
@@ -23,7 +28,12 @@ class CommentViewSet(viewsets.ModelViewSet):
 
     queryset = Comment.objects.all()
     serializer_class = CommentSerializer
-    permission_classes = [permissions.IsAuthenticated]
+
+    def get_permissions(self):
+        """Get permissions by action."""
+        if self.request.method == "GET":
+            return [permissions.AllowAny()]
+        return [permissions.IsAuthenticated()]
 
 
 @extend_schema(responses={200: CommentSerializer(many=True)})

--- a/backend/core/permissions.py
+++ b/backend/core/permissions.py
@@ -1,4 +1,4 @@
-"""Project permisssions."""
+"""Core permissions."""
 
 from rest_framework.permissions import BasePermission
 

--- a/backend/donation/views.py
+++ b/backend/donation/views.py
@@ -15,14 +15,16 @@ User = get_user_model()
 
 
 class DonationDetailAPI(APIView):
+    """Donation Detail API."""
+
     class OutputSerializer(serializers.ModelSerializer):
+        """Donation Detail Output Serializer."""
+
         class Meta:
             model = Donation
             fields = ("id", "donor", "amount", "campaign", "payment")
 
-    @extend_schema(
-        responses={200: OutputSerializer},
-    )
+    @extend_schema(responses={200: OutputSerializer})
     def get(self, request, donation_id):
         donation = donation_get(donation_id)
 
@@ -35,14 +37,16 @@ class DonationDetailAPI(APIView):
 
 
 class DonationListAPI(APIView):
+    """Donation List API."""
+
     class OutputSerializer(serializers.ModelSerializer):
+        """Donation List Output Serializer."""
+
         class Meta:
             model = Donation
             fields = ("id", "donor", "amount", "campaign", "payment")
 
-    @extend_schema(
-        responses={200: OutputSerializer},
-    )
+    @extend_schema(responses={200: OutputSerializer})
     def get(self, request):
         donations = donation_list()
 
@@ -52,7 +56,11 @@ class DonationListAPI(APIView):
 
 
 class DonationCreateAPI(APIView):
+    """Donation Create API."""
+
     class InputSerializer(serializers.ModelSerializer):
+        """Donation Create Input Serializer."""
+
         class Meta:
             model = Donation
             fields = ["id", "donor", "amount", "campaign"]

--- a/backend/project/views.py
+++ b/backend/project/views.py
@@ -14,8 +14,9 @@ from rest_framework.generics import (
 from rest_framework.response import Response
 from rest_framework.views import APIView
 
+from core.permissions import IsAdminUser
+
 from .models import Cause, Project, ProjectAssignment
-from .permissions import IsAdminUser
 from .serializers import (
     CauseSerializer,
     ProjectAssignmentSerializer,
@@ -30,7 +31,6 @@ class CauseListCreateView(ListCreateAPIView):
 
     queryset = Cause.objects.all()
     serializer_class = CauseSerializer
-    permission_classes = [permissions.IsAuthenticated]
 
     def perform_create(self, serializer):
         """Ensure only admins can create causes."""
@@ -45,7 +45,12 @@ class CauseRetrieveUpdateDestroyView(RetrieveUpdateDestroyAPIView):
 
     queryset = Cause.objects.all()
     serializer_class = CauseSerializer
-    permission_classes = [permissions.IsAuthenticated, IsAdminUser]
+
+    def get_permissions(self):
+        """Get permissions by action."""
+        if self.request.method == "GET":
+            return [permissions.AllowAny()]
+        return [permissions.IsAuthenticated(), IsAdminUser()]
 
     def perform_destroy(self, instance):
         """Prevent delete if any project is using this cause."""
@@ -59,7 +64,6 @@ class ProjectListCreateView(ListCreateAPIView):
 
     queryset = Project.objects.all()
     serializer_class = ProjectSerializer
-    permission_classes = [permissions.IsAuthenticated]
 
     def perform_create(self, serializer):
         """Ensure only admins can create projects."""
@@ -74,7 +78,12 @@ class ProjectRetrieveUpdateDestroyView(RetrieveUpdateDestroyAPIView):
 
     queryset = Project.objects.all()
     serializer_class = ProjectSerializer
-    permission_classes = [permissions.IsAuthenticated, IsAdminUser]
+
+    def get_permissions(self):
+        """Get permissions by action."""
+        if self.request.method == "GET":
+            return [permissions.AllowAny()]
+        return [permissions.IsAuthenticated(), IsAdminUser()]
 
 
 class AssignBeneficiaryView(APIView):
@@ -156,7 +165,6 @@ class ListAssignmentsView(ListAPIView):
     """List all assignments for a given Project."""
 
     serializer_class = ProjectAssignmentSerializer
-    permission_classes = [permissions.IsAuthenticated]
 
     def get_queryset(self):
         project_id = self.kwargs["project_id"]


### PR DESCRIPTION
Details:
- add sensible defaults for permissions:
  - for protected items (e.g Project) only admins can create, update or delete
  - for unprotected items (e.g Campaigns, Comments) only authenticated can create, update or delete
  - for everything else unauthenticated users can list and retrieve